### PR TITLE
Refactor udp_sendmsg for iov support

### DIFF
--- a/src/include/net/skbuff.h
+++ b/src/include/net/skbuff.h
@@ -217,6 +217,14 @@ extern struct sk_buff * skb_queue_pop(struct sk_buff_head *queue);
 
 extern int skb_queue_count(struct sk_buff_head *queue);
 
+static inline struct sk_buff * skb_queue_next(struct sk_buff *skb) {
+	return skb->lnk.next;
+}
+
+static inline int skb_queue_end(struct sk_buff *skb, struct sk_buff_head *queue) {
+	return (void *) queue == (void *) skb;
+}
+
 #define PAD_SIZE(obj_size, padto) \
 	(((padto) - (obj_size) % (padto)) % (padto))
 

--- a/src/net/socket/udp_sock.c
+++ b/src/net/socket/udp_sock.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <string.h>
+#include <util/math.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 
@@ -28,79 +29,133 @@
 #include <stdlib.h>
 
 static const struct sock_proto_ops udp_sock_ops_struct;
-const struct sock_proto_ops *const udp_sock_ops
-		= &udp_sock_ops_struct;
+const struct sock_proto_ops *const udp_sock_ops = &udp_sock_ops_struct;
 
 EMBOX_NET_SOCK(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 1,
 		udp_sock_ops_struct);
 
+static int iov_msg_len(struct iovec *iov, int iovlen) {
+	int len = 0;
+
+	for (int i = 0; i < iovlen; i++) {
+		len += iov[i].iov_len;
+	}
+
+	return len;
+}
+
+int iov_stream_make_queue(size_t len, size_t hdr_size, struct sk_buff_head *queue,
+		struct sock *sk, const struct sockaddr *sockaddr) {
+	int to_alloc = len;
+
+	skb_queue_init(queue);
+
+	while (to_alloc > 0) {
+		struct sk_buff *skb = NULL;
+		size_t actual_len = to_alloc + hdr_size;
+
+		int ret = sk->o_ops->make_pack(sk, sockaddr, &actual_len, &skb);
+		if (ret < 0) {
+			skb_queue_purge(queue);
+			return ret;
+		}
+		skb_queue_push(queue, skb);
+		to_alloc -= actual_len - hdr_size;
+	}
+
+	return len;
+}
+
+int iov_dgram_make_queue(size_t len, size_t hdr_size, struct sk_buff_head *queue,
+		struct sock *sk, const struct sockaddr *sockaddr) {
+
+	skb_queue_init(queue);
+
+	struct sk_buff *skb = NULL;
+	size_t actual_len = len + hdr_size;
+
+	int ret = sk->o_ops->make_pack(sk, sockaddr, &actual_len, &skb);
+	if (ret < 0) {
+		return ret;
+	}
+
+	skb_queue_push(queue, skb);
+	return actual_len - hdr_size;
+}
+
+static int skb_queue_iov(struct sk_buff_head *queue, const struct iovec *iov, int iovlen, size_t header_len) {
+	struct sk_buff *skb = skb_queue_front(queue);
+	int i_iov = 0;
+	int skb_pos = 0, iov_pos = 0;
+	int ret = 0;
+
+	while (!skb_queue_end(skb, queue) && (i_iov < iovlen)) {
+		const int to_copy = min(skb->len - skb_pos, iov[i_iov].iov_len - iov_pos);
+		memcpy(skb->mac.raw + header_len + skb_pos, iov[i_iov].iov_base + iov_pos, to_copy);
+
+		iov_pos += to_copy;
+		skb_pos += to_copy;
+		ret += to_copy;
+
+		if (skb->len == skb_pos) {
+			skb = skb_queue_next(skb);
+			skb_pos = 0;
+		}
+
+		if (iov[i_iov].iov_len == iov_pos) {
+			++i_iov;
+			iov_pos = 0;
+		}
+	}
+
+	return ret;
+}
+
+static int udp_get_udp_offset(struct sk_buff *skb) {
+	return (unsigned char *) (skb->h.uh) - skb->mac.raw;
+}
+
 static int udp_sendmsg(struct sock *sk, struct msghdr *msg, int flags) {
-	size_t total_len, data_len, actual_len, skb_len;
-	struct sk_buff *skb;
-	const struct sockaddr_in *to;
-	const struct sockaddr *sockaddr;
-	int i, ret;
+	const in_port_t sk_src = sock_inet_get_src_port(sk);
+	const struct sockaddr_in *const addr_to = (const struct sockaddr_in *)
+			(msg->msg_name ? msg->msg_name : &to_inet_sock(sk)->dst_in);
+	struct sk_buff_head queue;
+	int err;
 
-	assert(sk);
-	assert(sk->o_ops);
-	assert(sk->o_ops->make_pack);
-	assert(msg);
-	assert(msg->msg_iov);
-	assert(msg->msg_iov->iov_base);
+	const size_t iov_data_len = iov_msg_len(msg->msg_iov, msg->msg_iovlen);
 
-	data_len = 0;
-	for (i = 0; i < msg->msg_iovlen; i++) {
-		data_len += msg->msg_iov[i].iov_len;
+	// TODO msg->msg_name could be NULL, see around. Will NULL be OK?
+	const struct sockaddr *sockaddr = (const struct sockaddr *)msg->msg_name;
+
+	const int out_data_len = iov_dgram_make_queue(iov_data_len, UDP_HEADER_SIZE, &queue, sk, sockaddr);
+	if (out_data_len < 0) {
+		return out_data_len;
 	}
 
-	total_len = data_len + UDP_HEADER_SIZE;
+	// FIXME there should be a better way to get offset
+	const int skb_udp_offset = udp_get_udp_offset(queue.next);
 
-	skb = NULL;
-	sockaddr = (const struct sockaddr *)msg->msg_name;
+	const int bytes_copied = skb_queue_iov(&queue, msg->msg_iov, msg->msg_iovlen, skb_udp_offset + UDP_HEADER_SIZE);
+	assert(bytes_copied == out_data_len);
 
-	if (msg->msg_name != NULL) {
-		to = (const struct sockaddr_in *)msg->msg_name;
-	} else {
-		to = (const struct sockaddr_in *)&to_inet_sock(sk)->dst_in;
-	}
-
-	skb_len = i = 0;
-	while (i < msg->msg_iovlen) {
-		data_len -= skb_len;
-		actual_len = data_len + UDP_HEADER_SIZE;
-
-		ret = sk->o_ops->make_pack(sk, sockaddr, &actual_len, &skb);
-
-		if (ret != 0) {
-			return ret;
-		}
-
-		assert(skb);
-		assert(skb->h.uh);
-
-		skb_len = 0;
-
-		while (i < msg->msg_iovlen && skb_len + msg->msg_iov[i].iov_len <= actual_len) {
-			skb_len += msg->msg_iov[i].iov_len;
-			i++;
-		}
-
-		skb_buf_iovec(skb->h.uh + 1, skb_len, msg->msg_iov, msg->msg_iovlen);
-
-		udp_build(skb->h.uh, sock_inet_get_src_port(sk), to->sin_port,
-				skb_len + UDP_HEADER_SIZE);
-
+	err = 0;
+	for (struct sk_buff *skb = skb_queue_pop(&queue); skb; skb = skb_queue_pop(&queue)) {
+		udp_build(skb->h.uh, sk_src, addr_to->sin_port, skb->len - skb_udp_offset);
 		udp4_set_check_field(skb->h.uh, skb->nh.iph);
-
-		assert(sk->o_ops->snd_pack);
-		ret = sk->o_ops->snd_pack(skb);
-
-		if (0 > ret) {
-			return ret;
+		err = sk->o_ops->snd_pack(skb);
+		if (err < 0) {
+			break;
 		}
 	}
 
-	return total_len - UDP_HEADER_SIZE;
+	if (err < 0) {
+		skb_queue_purge(&queue);
+		return err;
+	}
+
+	assert(skb_queue_front(&queue) == NULL); // should be empty at this point
+
+	return out_data_len;
 }
 
 static DLIST_DEFINE(udp_sock_list);

--- a/src/net/socket/udp_sock.c
+++ b/src/net/socket/udp_sock.c
@@ -124,7 +124,7 @@ static int udp_sendmsg(struct sock *sk, struct msghdr *msg, int flags) {
 
 	const size_t iov_data_len = iov_msg_len(msg->msg_iov, msg->msg_iovlen);
 
-	// TODO msg->msg_name could be NULL, see around. Will NULL be OK?
+	// msg->msg_name could be NULL, sockaddr is OK to be NULL
 	const struct sockaddr *sockaddr = (const struct sockaddr *)msg->msg_name;
 
 	const int out_data_len = iov_dgram_make_queue(iov_data_len, UDP_HEADER_SIZE, &queue, sk, sockaddr);


### PR DESCRIPTION
Hi!

Could you please review refactoring of udp_sendmsg?

The function was separated to individual steps: calculate cumulative length of input buffer, allocate queue of skb to match the input, fill and send them in row. This should improve error handling: if allocate fail on some step, we'll be sure no packets was sent before. 
I'm still not sure if we need to break transmission of the queue if we got error of single packet TX (line 147). Errors on this stage should mean temporary outage, next transmission will successed with high probability (except, may be,network driver broke the NIC forever).

Note the use of skb_queue. skb itself is some sort of scatter-gather buffer, so routines like `skb_queue_iov` are very handy. `skb_iov_queue` is not there, but it will be required for stream sockets, not dgram.

MANY functions aren't on their places. iov utils will be moved near to skb, like skb_iovec_buf. iov utilities deserves own place.

Please, review the change and give a comment what do you think about: everything ok, or there could be an improvements, mistakes spotted, notes, etc... 
I performed no testing other than socket_test. Can you try to extend socket_test to break this?

Thanks,
Anton
